### PR TITLE
Refreshes subject list on page load

### DIFF
--- a/Frontend/eduShare/src/app/components/material-form/material-form.component.ts
+++ b/Frontend/eduShare/src/app/components/material-form/material-form.component.ts
@@ -56,9 +56,9 @@ export class MaterialFormComponent implements OnInit {
     }
     fileControl?.updateValueAndValidity()
 
-    this.subjects$ = this.subjectService.subjects$.pipe(
+    this.subjects$ = this.subjectService.getAllSubjects().pipe(
       map(subjects => subjects.slice().sort((a, b) => a.name.localeCompare(b.name)))
-    )
+    );
   }
 
   get description() {


### PR DESCRIPTION
Ensures the subject list is reloaded every time the page is loaded. This fixes an issue where the subject list was not updating correctly.

The component now calls `getAllSubjects()` on initialization to populate the subjects.

Relates to #88