### PR TITLE
Reduces top margin on material view

### DIFF
--- a/Frontend/eduShare/src/app/components/material-view/material-view.component.html
+++ b/Frontend/eduShare/src/app/components/material-view/material-view.component.html
@@ -1,4 +1,4 @@
-<div class="container-fluid py-5 mt-5">
+<div class="container-fluid py-5 mt-2">
   <div class="row w-100 justify-content-center align-items-start">
     <div class="col-md-7 d-flex justify-content-center">
       <div class="container mt-4" *ngIf="material">


### PR DESCRIPTION
Reduces the top margin of the material view to improve spacing.

The original margin was too large, creating excessive space at the top of the view. This change adjusts the margin to provide a more visually appealing layout.

Fixes #185