### PR TITLE
Updates profile image in navbar after update

### DIFF
--- a/Frontend/eduShare/src/app/components/navbar/navbar.component.html
+++ b/Frontend/eduShare/src/app/components/navbar/navbar.component.html
@@ -34,7 +34,7 @@
             <img *ngIf="profile?.image?.file" [src]="getProfileImageSrc()" [alt]="profile?.fullName" class="avatar" />
           </button>
           <ul class="dropdown-menu dropdown-menu-end">
-            <li><button class="dropdown-item" (click)="openProfile(this.id)">View profile</button></li>
+            <li><button class="dropdown-item" (click)="openProfile()">View profile</button></li>
             <li><button class="dropdown-item" (click)="openFavs()">Favourites</button></li>
             <li><button class="dropdown-item" (click)="logout()">Log out</button></li>
           </ul>

--- a/Frontend/eduShare/src/app/components/navbar/navbar.component.ts
+++ b/Frontend/eduShare/src/app/components/navbar/navbar.component.ts
@@ -28,19 +28,19 @@ export class NavbarComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-    this.id = this.auth.getUserId() || '';
-    this.isLoggedIn = this.auth.isLoggedIn()
-    this.profileService.getById(this.id).subscribe({
-      next: (data) => {
-        this.profile = data
-        console.log(this.profile)
-      },
-      error: (err) => {
-        console.error(err)
-        alert('Nem sikerült betölteni a profilt.')
-        this.auth.logout()
-      }
-    })
+    this.isLoggedIn = this.auth.isLoggedIn();
+
+    // Feliratkozunk a currentProfile$-ra, így mindig friss lesz
+    this.profileService.currentProfile$.subscribe(profile => {
+      this.profile = profile;
+      console.log(profile)
+    });
+
+    const userId = this.auth.getUserId();
+    if (userId) {
+      this.profileService.getCurrentProfile(userId).subscribe();
+    }
+
     this.isTeacher = this.auth.getRoles().some(r => r === 'Teacher' || r === 'Admin')
     this.isAdmin = this.auth.getRoles().some(r => r === 'Admin')
   }
@@ -55,8 +55,8 @@ export class NavbarComponent implements OnChanges, OnInit {
     this.router.navigate(['/fav-materials'])
   }
 
-  openProfile(profileId: string): void {
-    this.router.navigate(['/profile-view', profileId])
+  openProfile(): void {
+    this.router.navigate(['/profile-view', this.auth.getUserId()])
   }
 
   ngOnChanges() {

--- a/Frontend/eduShare/src/app/dtos/image-dto.ts
+++ b/Frontend/eduShare/src/app/dtos/image-dto.ts
@@ -1,5 +1,5 @@
-export interface ImageDto {
-    id: string
-    fileName: string
-    file: string
+export class ImageDto {
+    id: string = ""
+    fileName: string = ""
+    file: string = ""
 }

--- a/Frontend/eduShare/src/app/dtos/profile-view-dto.ts
+++ b/Frontend/eduShare/src/app/dtos/profile-view-dto.ts
@@ -2,12 +2,12 @@ import { ImageDto } from "./image-dto"
 import { MaterialShortViewDto } from "./material-short-view-dto"
 import { MaterialViewForProfileDto } from "./material-view-for-profile-dto"
 
-export interface ProfileViewDto {
-    id:string
-    fullName:string
-    email:string
-    image:ImageDto
-    materials:MaterialShortViewDto[]
+export class ProfileViewDto {
+    id:string = ""
+    fullName:string = ""
+    email:string = ""
+    image:ImageDto = new ImageDto
+    materials:MaterialShortViewDto[] = []
     isWarned?: boolean
     isBanned?: boolean
     warnedAt?: string

--- a/Frontend/eduShare/src/app/services/profile.service.ts
+++ b/Frontend/eduShare/src/app/services/profile.service.ts
@@ -19,8 +19,17 @@ export class ProfileService {
   private _uploaders$ = new BehaviorSubject<SearchUploaderDto[]>([])
   public uploaders$ = this._uploaders$.asObservable()
 
+  private _currentProfile$ = new BehaviorSubject<ProfileViewDto>(new ProfileViewDto);
+  public currentProfile$ = this._currentProfile$.asObservable();
+
   constructor(private http: HttpClient) 
   { }
+
+  getCurrentProfile(id: string): Observable<ProfileViewDto> {
+    return this.http.get<ProfileViewDto>(`${this.apiBaseUrl}/${id}`).pipe(
+      tap(profile => this._currentProfile$.next(profile))
+    );
+  }
 
   loadAll(): Observable<ProfilListViewDto[]> {
     return this.http.get<ProfilListViewDto[]>(this.apiBaseUrl).pipe(
@@ -38,12 +47,10 @@ export class ProfileService {
       return this.http.get<ProfileViewDto>(`${this.apiBaseUrl}/${id}`);
     }
       
-  update(id: string, profile: UpdateProfileDto): Observable<void> {
-    return this.http.put<void>(`${this.apiBaseUrl}/${id}`, profile).pipe(
-      switchMap(() => this.http.get<ProfileViewDto[]>(this.apiBaseUrl)),
-      tap(updated => this.profileShortSubject.next(updated)),
-      map(() => void 0)
-    )
+  update(id: string, profile: UpdateProfileDto) {
+    return this.http.put(`${this.apiBaseUrl}/${id}`, profile).pipe(
+      tap(() => this.getCurrentProfile(id).subscribe())
+    );
   }
 
   grantAdmin(id:string): Observable<void> {


### PR DESCRIPTION
Updates the profile image displayed in the navbar immediately after a user updates their profile. This ensures the user sees the updated image without needing to refresh the page.

The navbar now subscribes to the profile service's `currentProfile$` observable to reactively update the profile information. The component retrieves the current user's profile when initialized, and uses the auth service to get the user id. The `openProfile` method now uses the auth service to get the user id to navigate to the profile view.

The `ImageDto` and `ProfileViewDto` are now classes with default values to prevent null reference errors.